### PR TITLE
Simplify Timeline and CFP sections for better readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -1331,53 +1331,51 @@
         </div>
         <div class="relative">
           <!-- 縦棒（タイムライン全体） -->
-          <div class="absolute left-5 top-0 bottom-0 w-1 bg-gradient-to-b from-yellow-400 via-blue-400 to-purple-500 rounded-full" style="z-index:0;"></div>
-          <div class="space-y-20">
+          <div class="absolute left-5 top-0 bottom-0 w-1 bg-blue-500 rounded-full" style="z-index:0;"></div>
+          <div class="space-y-16">
             <!-- 1. CFP募集開始 -->
             <div class="relative flex items-start">
               <div class="flex flex-col items-center z-10 pr-4" style="width: 3.5rem;">
-                <div class="w-10 h-10 bg-orange-400 border-4 border-white rounded-full flex items-center justify-center shadow-lg mb-4 p-6">
-                  <i class="fas fa-bullhorn text-white text-2xl"></i>
+                <div class="w-10 h-10 bg-blue-500 border-4 border-white rounded-full flex items-center justify-center shadow-lg mb-4">
+                  <i class="fas fa-bullhorn text-white text-xl"></i>
                 </div>
               </div>
               <div class="ml-8 flex-1">
-                <div class="glass-strong solarium-warm glass-hover warm-glow p-8 rounded-2xl border-2 border-yellow-200/50 natural-shadow">
+                <div class="bg-white p-6 rounded-xl border border-gray-200 shadow-sm">
                   <div class="flex items-center mb-2">
-                    <span class="text-lg font-bold text-orange-600 mr-4">2025年5月20日</span>
+                    <span class="text-lg font-bold text-blue-600 mr-4">2025年5月20日</span>
                     <span class="text-gray-900 font-semibold">CFP募集開始</span>
                   </div>
-                  <p class="text-gray-700 mb-4">登壇者の募集を開始します</p>
-                  <a href="https://docs.google.com/forms/d/e/1FAIpQLSdUFdrd5y2m4D0YQ8QgyxfnsNcs9zPdBkgWfeIO_0WWbMfEhQ/viewform?usp=dialog" target="_blank" rel="noopener" class="inline-block mt-2 px-6 py-3 rounded-full font-bold text-white bg-gradient-to-r from-orange-400 to-pink-500 shadow-lg hover:scale-105 transition-all duration-300">CFP応募フォーム</a>
+                  <p class="text-gray-700">登壇者の募集を開始します</p>
                 </div>
               </div>
             </div>
             <!-- 2. CFP締切 -->
             <div class="relative flex items-start">
               <div class="flex flex-col items-center z-10 pr-4" style="width: 3.5rem;">
-                <div class="w-10 h-10 bg-red-500 border-4 border-white rounded-full flex items-center justify-center shadow-lg mb-2 p-6">
-                  <i class="fas fa-calendar-times text-white text-2xl"></i>
+                <div class="w-10 h-10 bg-blue-500 border-4 border-white rounded-full flex items-center justify-center shadow-lg mb-2">
+                  <i class="fas fa-calendar-times text-white text-xl"></i>
                 </div>
               </div>
               <div class="ml-8 flex-1">
-                <div class="glass-strong solarium-accent glass-hover warm-glow p-8 rounded-2xl border-2 border-red-200/50 natural-shadow">
+                <div class="bg-white p-6 rounded-xl border border-gray-200 shadow-sm">
                   <div class="flex items-center mb-2">
-                    <span class="text-lg font-bold text-red-600 mr-4">2025年6月13日 24:00ごろ</span>
+                    <span class="text-lg font-bold text-blue-600 mr-4">2025年6月13日 24:00ごろ</span>
                     <span class="text-gray-900 font-semibold">CFP締切</span>
                   </div>
-                  <p class="text-gray-700 mb-4">登壇応募の締切日です</p>
-                  <a href="https://docs.google.com/forms/d/e/1FAIpQLSdUFdrd5y2m4D0YQ8QgyxfnsNcs9zPdBkgWfeIO_0WWbMfEhQ/viewform?usp=dialog" target="_blank" rel="noopener" class="inline-block mt-2 px-6 py-3 rounded-full font-bold text-white bg-gradient-to-r from-orange-400 to-pink-500 shadow-lg hover:scale-105 transition-all duration-300">CFP応募フォーム</a>
+                  <p class="text-gray-700">登壇応募の締切日です</p>
                 </div>
               </div>
             </div>
             <!-- 3. 参加登録開始 -->
             <div class="relative flex items-start">
               <div class="flex flex-col items-center z-10 pr-4" style="width: 3.5rem;">
-                <div class="w-10 h-10 bg-blue-500 border-4 border-white rounded-full flex items-center justify-center shadow-lg mb-2 p-6">
-                  <i class="fas fa-user-plus text-white text-2xl"></i>
+                <div class="w-10 h-10 bg-blue-500 border-4 border-white rounded-full flex items-center justify-center shadow-lg mb-2">
+                  <i class="fas fa-user-plus text-white text-xl"></i>
                 </div>
               </div>
               <div class="ml-8 flex-1">
-                <div class="glass-strong solarium-cool glass-hover warm-glow p-8 rounded-2xl border-2 border-blue-200/50 natural-shadow">
+                <div class="bg-white p-6 rounded-xl border border-gray-200 shadow-sm">
                   <div class="flex items-center mb-2">
                     <span class="text-lg font-bold text-blue-600 mr-4">2025年6月中旬</span>
                     <span class="text-gray-900 font-semibold">参加登録開始</span>
@@ -1389,14 +1387,14 @@
             <!-- 4. イベント当日 -->
             <div class="relative flex items-start">
               <div class="flex flex-col items-center z-10 pr-4" style="width: 3.5rem;">
-                <div class="w-10 h-10 bg-purple-500 border-4 border-white rounded-full flex items-center justify-center shadow-lg mb-2 p-6">
-                  <i class="fas fa-calendar-check text-white text-2xl"></i>
+                <div class="w-10 h-10 bg-blue-500 border-4 border-white rounded-full flex items-center justify-center shadow-lg mb-2">
+                  <i class="fas fa-calendar-check text-white text-xl"></i>
                 </div>
               </div>
               <div class="ml-8 flex-1">
-                <div class="glass-strong solarium-accent glass-hover warm-glow p-8 rounded-2xl border-2 border-purple-200/50 natural-shadow">
+                <div class="bg-white p-6 rounded-xl border border-gray-200 shadow-sm">
                   <div class="flex items-center mb-2">
-                    <span class="text-lg font-bold text-purple-600 mr-4">2025年7月26日</span>
+                    <span class="text-lg font-bold text-blue-600 mr-4">2025年7月26日</span>
                     <span class="text-gray-900 font-semibold">イベント当日</span>
                   </div>
                   <p class="text-gray-700">Devin Meetup Tokyo 開催！</p>
@@ -1420,126 +1418,42 @@
                 </p>
                 
                 <!-- Call for Proposal Banner -->
-                <div class="glass-strong solarium-accent warm-glow bg-gradient-to-r from-orange-500/60 to-red-500/60 text-gray-800 p-8 rounded-3xl mb-12 border-2 border-orange-200/50 natural-shadow-strong">
-                    <div class="flex items-center justify-center mb-6">
-                        <i class="fas fa-bullhorn text-4xl mr-4 text-orange-600"></i>
-                        <h3 class="text-3xl font-bold text-gray-900">Call for Proposals 募集中！</h3>
-                    </div>
-                    <p class="text-xl mb-8 text-gray-700 leading-relaxed text-center">
-                        Devinの活用事例、技術解説、実装体験など、あなたの知見をシェアしませんか？
-                    </p>
-                    
-                    <!-- 募集要項詳細 -->
-                    <div class="grid md:grid-cols-2 gap-8 mb-8">
-                        <div class="glass solarium-warm p-6 rounded-2xl border border-orange-200/50">
-                            <h4 class="text-xl font-bold text-gray-900 mb-4 flex items-center">
-                                <i class="fas fa-calendar-check text-orange-600 mr-3"></i>
-                                公募期間
-                            </h4>
-                            <div class="text-gray-700 space-y-2">
-                                <p class="text-lg"><strong>募集終了：</strong></p>
-                                <p class="text-2xl font-bold text-red-600">2025年6月13日 24:00ごろ</p>
-                            </div>
-                        </div>
-                        
-                        <div class="glass solarium-cool p-6 rounded-2xl border border-blue-200/50">
-                            <h4 class="text-xl font-bold text-gray-900 mb-4 flex items-center">
-                                <i class="fas fa-file-alt text-blue-600 mr-3"></i>
-                                応募フォーム
-                            </h4>
-                            <div class="text-gray-700 space-y-2">
-                                <a href="https://docs.google.com/forms/d/e/1FAIpQLSdUFdrd5y2m4D0YQ8QgyxfnsNcs9zPdBkgWfeIO_0WWbMfEhQ/viewform?usp=dialog" target="_blank" rel="noopener" class="inline-block mt-2 px-6 py-3 rounded-full font-bold text-white bg-gradient-to-r from-blue-400 to-purple-500 shadow-lg hover:scale-105 transition-all duration-300">CFP応募フォーム</a>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <!-- 求める登壇内容 -->
-                    <div class="mb-12">
-                        <div class="glass-strong solarium-accent bg-gradient-to-br from-white/80 via-orange-50/80 to-yellow-100/70 p-12 rounded-3xl border-2 border-yellow-100/60 natural-shadow-strong warm-glow flex flex-col items-center">
-                            <div class="mb-8 flex flex-col items-center">
-                                <div class="w-16 h-16 flex items-center justify-center rounded-full bg-gradient-to-br from-yellow-300/80 to-orange-200/60 shadow-lg mb-4">
-                                    <i class="fas fa-lightbulb text-yellow-500 text-3xl"></i>
-                                </div>
-                                <h4 class="text-3xl md:text-4xl font-extrabold text-gray-900 mb-2 tracking-tight" style="letter-spacing: -0.01em;">こんなトークをお待ちしています</h4>
-                                <p class="text-lg md:text-xl text-gray-700 font-medium opacity-80 text-center max-w-2xl">
-                                    これまでにないDevinの活用法や、<span class="text-orange-500 font-semibold">よりスマートで効率的な使い方</span>の体験談・アイデアをぜひご提案ください。
-                                </p>
-                            </div>
-                            <div class="grid md:grid-cols-2 gap-8 w-full mb-8">
-                                <div class="glass solarium-warm p-6 rounded-2xl border border-yellow-100/60 shadow-md flex flex-col items-center hover:scale-105 transition-all duration-300">
-                                    <i class="fas fa-magic text-purple-400 text-2xl mb-3"></i>
-                                    <h5 class="font-semibold text-gray-900 mb-2 text-lg">独自のワークフロー</h5>
-                                    <p class="text-gray-700 text-center text-sm opacity-80">Devinを組み込んだ独創的な開発プロセスや効率化の工夫</p>
-                                </div>
-                                <div class="glass solarium-cool p-6 rounded-2xl border border-blue-100/60 shadow-md flex flex-col items-center hover:scale-105 transition-all duration-300">
-                                    <i class="fas fa-cogs text-blue-400 text-2xl mb-3"></i>
-                                    <h5 class="font-semibold text-gray-900 mb-2 text-lg">応用的な使い方</h5>
-                                    <p class="text-gray-700 text-center text-sm opacity-80">従来の枠を超えた、意外な分野での活用事例</p>
-                                </div>
-                                <div class="glass solarium-accent p-6 rounded-2xl border border-purple-100/60 shadow-md flex flex-col items-center hover:scale-105 transition-all duration-300">
-                                    <i class="fas fa-brain text-orange-400 text-2xl mb-3"></i>
-                                    <h5 class="font-semibold text-gray-900 mb-2 text-lg">生産性向上ハック</h5>
-                                    <p class="text-gray-700 text-center text-sm opacity-80">Devinの特性を活かした時短術や品質向上テクニック</p>
-                                </div>
-                                <div class="glass solarium-warm p-6 rounded-2xl border border-red-100/60 shadow-md flex flex-col items-center hover:scale-105 transition-all duration-300">
-                                    <i class="fas fa-puzzle-piece text-indigo-400 text-2xl mb-3"></i>
-                                    <h5 class="font-semibold text-gray-900 mb-2 text-lg">創造的な組み合わせ</h5>
-                                    <p class="text-gray-700 text-center text-sm opacity-80">他ツールとの連携や、予想外の用途での成功事例</p>
-                                </div>
-                            </div>
-                            <div class="w-full max-w-2xl mx-auto bg-gradient-to-r from-white/80 to-blue-50/80 glass-strong rounded-2xl border border-blue-100/60 px-8 py-6 flex items-center shadow-sm">
-                                <i class="fas fa-quote-left text-blue-300 text-2xl mr-4"></i>
-                                <div>
-                                    <p class="text-gray-700 text-base md:text-lg font-medium mb-1" style="letter-spacing: -0.01em;">
-                                        愚直にDevinを使うのではなく、<span class="text-blue-500 font-semibold">あなたならではの工夫や発見</span>、<br class="hidden md:block">より洗練された活用法のストーリーをお待ちしています。
-                                    </p>
-                                    <p class="text-sm text-gray-500">失敗談や意外な気づき、独自の改善点なども大歓迎です。</p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <!-- 登壇形式 -->
-                    <div class="mb-8">
-                        <h4 class="text-2xl font-bold text-gray-900 mb-6 text-center">登壇形式について</h4>
-                        <p class="text-gray-700 mb-6 text-center">
-                            以下の2種類の登壇形式でトークプロポーザルを募集します。<br>
-                            ご自身の発信内容やスタイルに合わせて、より適していると感じる形式でご応募ください。
+                <div class="bg-gradient-to-r from-orange-100 to-red-100 p-6 rounded-xl mb-8 border border-orange-200">
+                    <div class="text-center mb-6">
+                        <h3 class="text-2xl font-bold text-gray-900 mb-4">Call for Proposals 募集中！</h3>
+                        <p class="text-lg text-gray-700 mb-4">
+                            Devinの活用事例、技術解説、実装体験など、あなたの知見をシェアしませんか？
                         </p>
-                        
-                        <div class="grid md:grid-cols-2 gap-6">
-                            <div class="glass solarium-accent p-6 rounded-2xl border-2 border-purple-200/50 text-center hover:scale-105 hover:shadow-2xl hover:border-purple-300/70 transition-all duration-500 group">
-                                <div class="w-16 h-16 bg-purple-600 rounded-full flex items-center justify-center mx-auto mb-4 group-hover:rotate-12 group-hover:scale-110 transition-all duration-500">
-                                    <i class="fas fa-microphone text-white text-2xl group-hover:scale-110 transition-transform duration-300"></i>
-                                </div>
-                                <h5 class="text-xl font-bold text-gray-900 mb-2 group-hover:text-purple-700 transition-colors duration-300">レギュラートーク</h5>
-                                <div class="text-3xl font-bold text-purple-600 mb-3 group-hover:scale-110 transition-transform duration-300">30分</div>
-                                <p class="text-gray-700 text-sm group-hover:text-gray-800 transition-colors duration-300">
-                                    深い技術解説や詳細な事例紹介に最適
-                                </p>
-                            </div>
-                            
-                            <div class="glass solarium-warm p-6 rounded-2xl border-2 border-orange-200/50 text-center hover:scale-105 hover:shadow-2xl hover:border-orange-300/70 transition-all duration-500 group">
-                                <div class="w-16 h-16 bg-orange-600 rounded-full flex items-center justify-center mx-auto mb-4 group-hover:rotate-12 group-hover:scale-110 transition-all duration-500">
-                                    <i class="fas fa-bolt text-white text-2xl group-hover:scale-110 transition-transform duration-300"></i>
-                                </div>
-                                <h5 class="text-xl font-bold text-gray-900 mb-2 group-hover:text-orange-700 transition-colors duration-300">Short talk</h5>
-                                <div class="text-3xl font-bold text-orange-600 mb-3 group-hover:scale-110 transition-transform duration-300">10分</div>
-                                <p class="text-gray-700 text-sm group-hover:text-gray-800 transition-colors duration-300">
-                                    体験談やTips、アイデア共有に最適
-                                </p>
-                            </div>
+                    </div>
+                    
+                    <div class="grid md:grid-cols-2 gap-6 mb-6">
+                        <div class="bg-white p-4 rounded-lg border border-orange-200">
+                            <h4 class="text-lg font-bold text-gray-900 mb-2">募集期間</h4>
+                            <p class="text-gray-700">2025年5月20日 〜 2025年6月13日 24:00ごろ</p>
+                        </div>
+                        <div class="bg-white p-4 rounded-lg border border-orange-200">
+                            <h4 class="text-lg font-bold text-gray-900 mb-2">登壇形式</h4>
+                            <p class="text-gray-700">レギュラートーク（30分）・Short talk（10分）</p>
                         </div>
                     </div>
                     
-                    <div class="flex flex-col sm:flex-row gap-4 justify-center">
-                        <a href="https://docs.google.com/forms/d/e/1FAIpQLSdUFdrd5y2m4D0YQ8QgyxfnsNcs9zPdBkgWfeIO_0WWbMfEhQ/viewform?usp=dialog" target="_blank" rel="noopener" class="glass solarium-warm text-gray-800 px-8 py-4 rounded-full font-semibold hover:scale-105 hover:shadow-2xl hover:bg-gradient-to-r hover:from-orange-400/80 hover:to-red-400/80 transition-all duration-500 border border-orange-300/50 natural-shadow group inline-flex items-center justify-center text-lg">
-                            <i class="fas fa-microphone mr-2 group-hover:rotate-12 transition-transform duration-300"></i>
-                            レギュラートーク応募
-                        </a>
-                        <a href="https://docs.google.com/forms/d/e/1FAIpQLSdUFdrd5y2m4D0YQ8QgyxfnsNcs9zPdBkgWfeIO_0WWbMfEhQ/viewform?usp=dialog" target="_blank" rel="noopener" class="glass solarium-cool text-gray-800 px-8 py-4 rounded-full font-semibold hover:scale-105 hover:shadow-2xl hover:bg-gradient-to-r hover:from-blue-400/80 hover:to-purple-400/80 transition-all duration-500 border border-blue-300/50 natural-shadow group inline-flex items-center justify-center text-lg">
-                            <i class="fas fa-lightning-bolt mr-2 group-hover:rotate-12 transition-transform duration-300"></i>
-                            Short talk応募
+                    <div class="bg-white p-6 rounded-xl border border-gray-200 mb-6">
+                        <h4 class="text-xl font-bold text-gray-900 mb-4">こんなトークをお待ちしています</h4>
+                        <p class="text-gray-700 mb-4">
+                            Devinの独創的な活用法や効率的な使い方の体験談・アイデアをご提案ください。
+                        </p>
+                        <ul class="space-y-2 text-gray-700">
+                            <li>• 独自のワークフローや開発プロセスの工夫</li>
+                            <li>• 従来の枠を超えた応用的な使い方</li>
+                            <li>• 生産性向上のためのハックやテクニック</li>
+                            <li>• 他ツールとの創造的な組み合わせ事例</li>
+                        </ul>
+                    </div>
+                    
+                    <div class="text-center">
+                        <a href="https://docs.google.com/forms/d/e/1FAIpQLSdUFdrd5y2m4D0YQ8QgyxfnsNcs9zPdBkgWfeIO_0WWbMfEhQ/viewform?usp=dialog" target="_blank" rel="noopener" class="inline-block bg-gradient-to-r from-orange-500 to-red-500 text-white px-8 py-4 rounded-full font-semibold hover:scale-105 transition-all duration-300 shadow-lg">
+                            <i class="fas fa-microphone mr-2"></i>
+                            CFP応募フォーム
                         </a>
                     </div>
                 </div>
@@ -2318,4 +2232,4 @@
         });
     </script>
 </body>
-</html>                                                
+</html>                                                                                                

--- a/index.html
+++ b/index.html
@@ -1331,7 +1331,7 @@
         </div>
         <div class="relative">
           <!-- 縦棒（タイムライン全体） -->
-          <div class="absolute left-5 top-0 bottom-0 w-1 bg-blue-500 rounded-full" style="z-index:0;"></div>
+          <div class="absolute left-5 top-0 bottom-0 w-1 bg-blue-500 rounded-full hidden sm:block" style="z-index:0;"></div>
           <div class="space-y-16">
             <!-- 1. CFP募集開始 -->
             <div class="relative flex items-start">


### PR DESCRIPTION
# Simplify Timeline and CFP sections for better readability

## Summary

This PR significantly simplifies the Timeline and CFP sections of the Devin Meetup Tokyo 2025 website by reducing visual complexity and consolidating redundant information. The changes focus on improving readability while preserving all essential event information and functionality.

**Key Changes:**

**Timeline Section:**
- Unified visual decorations with consistent blue color scheme (previously used different colors per milestone)
- Replaced complex gradient timeline bar with simple solid blue line
- Removed extensive glass effects (`glass-strong`, `solarium-*`, `warm-glow`, `natural-shadow`)
- Eliminated duplicate CFP buttons from individual timeline milestones
- Preserved all 4 key dates and descriptions

**CFP Section:**
- Condensed lengthy explanations from complex nested layouts to simple bullet points
- Consolidated 4 CFP application buttons down to 1 central button
- Simplified talk format descriptions while maintaining essential information
- Removed excessive visual decorations and animations
- Maintained the same Google Form link for applications

**Results:** 133 lines deleted, 47 lines added - significant reduction in complexity while preserving functionality.

## Review & Testing Checklist for Human

- [ ] **Visual design verification**: Check that the simplified styling still looks professional and matches the overall site aesthetic on both desktop and mobile
- [ ] **Japanese content accuracy**: Verify that the condensed Japanese explanations retain all important information and read naturally
- [ ] **CFP functionality testing**: Test the single remaining CFP button works correctly and that removing the other 3 buttons doesn't impact user experience
- [ ] **Cross-device compatibility**: Test on mobile devices and different browsers to ensure responsive design works properly
- [ ] **Content completeness**: Confirm that all essential CFP requirements and event timeline information is still clearly communicated

**Recommended test plan:** Load the site on desktop and mobile, scroll to Timeline and CFP sections, verify visual appearance, test CFP button functionality, and review Japanese text for clarity.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    index["index.html<br/>(Main site file)"]:::major-edit
    timeline["Timeline Section<br/>(Lines 1322-1407)"]:::major-edit
    cfp["CFP Section<br/>(Lines 1410-1460)"]:::major-edit
    
    index --> timeline
    index --> cfp
    
    timeline --> dates["4 Key Dates<br/>(Preserved)"]:::context
    timeline --> buttons1["CFP Buttons<br/>(Removed)"]:::minor-edit
    
    cfp --> content["Detailed Content<br/>(Condensed to bullets)"]:::major-edit
    cfp --> buttons2["4 CFP Buttons<br/>(Consolidated to 1)"]:::major-edit
    cfp --> form["Google Form Link<br/>(Preserved)"]:::context
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This change removes significant visual complexity (gradient backgrounds, glass effects, multiple color schemes) in favor of clean, unified styling
- All essential information is preserved: event dates, CFP deadlines, application link, and content requirements
- The single remaining CFP button uses the same Google Form URL as the original 4 buttons
- Changes were tested locally on desktop Chrome at http://localhost:8000

**Link to Devin run:** https://app.devin.ai/sessions/3d3ec53534054c50956f492220561b5f  
**Requested by:** @fumiya-kume

**Before/After Screenshots:**
![Before - Complex Timeline](file:///home/ubuntu/screenshots/localhost_8000_130455.png)
![After - Simplified sections](file:///home/ubuntu/screenshots/localhost_8000_130944.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * タイムラインの色を青と白に統一し、グラデーションやガラス効果を削除しました。
  * タイムライン項目間の間隔を縮小し、アイコンのサイズと背景色を統一しました。
  * イベント日付の色を青に統一しました。
  * イベント詳細の背景をシンプルな白と控えめな枠線・影に変更しました。
  * CFPバナーと応募セクションのデザインを簡素化し、情報を整理しました。
  * 複数の応募ボタンを1つに統合し、見た目をシンプルにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->