### PR TITLE
Remove Timeline and CFP sections completely

### DIFF
--- a/index.html
+++ b/index.html
@@ -1318,93 +1318,6 @@
         </div>
     </section>
 
-    <!-- Timeline Section -->
-    <section id="timeline" class="py-20 bg-white scroll-mt-24">
-      <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="text-center mb-16">
-          <h2 class="text-4xl md:text-5xl font-bold text-gray-900 mb-6">
-            イベントまでのタイムライン
-          </h2>
-          <p class="text-xl text-gray-600 max-w-2xl mx-auto">
-            Devin Meetup Tokyo 2025 までの主なスケジュールをご案内します。
-          </p>
-        </div>
-        <div class="relative">
-          <!-- 縦棒（タイムライン全体） -->
-          <div class="absolute left-5 top-0 bottom-0 w-1 bg-blue-500 rounded-full hidden sm:block" style="z-index:0;"></div>
-          <div class="space-y-16">
-            <!-- 1. CFP募集開始 -->
-            <div class="relative flex items-start">
-              <div class="flex flex-col items-center z-10 pr-4" style="width: 3.5rem;">
-                <div class="w-10 h-10 bg-blue-500 border-4 border-white rounded-full flex items-center justify-center shadow-lg mb-4">
-                  <i class="fas fa-bullhorn text-white text-xl"></i>
-                </div>
-              </div>
-              <div class="ml-8 flex-1">
-                <div class="bg-white p-6 rounded-xl border border-gray-200 shadow-sm">
-                  <div class="flex items-center mb-2">
-                    <span class="text-lg font-bold text-blue-600 mr-4">2025年5月20日</span>
-                    <span class="text-gray-900 font-semibold">CFP募集開始</span>
-                  </div>
-                  <p class="text-gray-700">登壇者の募集を開始します</p>
-                </div>
-              </div>
-            </div>
-            <!-- 2. CFP締切 -->
-            <div class="relative flex items-start">
-              <div class="flex flex-col items-center z-10 pr-4" style="width: 3.5rem;">
-                <div class="w-10 h-10 bg-blue-500 border-4 border-white rounded-full flex items-center justify-center shadow-lg mb-2">
-                  <i class="fas fa-calendar-times text-white text-xl"></i>
-                </div>
-              </div>
-              <div class="ml-8 flex-1">
-                <div class="bg-white p-6 rounded-xl border border-gray-200 shadow-sm">
-                  <div class="flex items-center mb-2">
-                    <span class="text-lg font-bold text-blue-600 mr-4">2025年6月13日 24:00ごろ</span>
-                    <span class="text-gray-900 font-semibold">CFP締切</span>
-                  </div>
-                  <p class="text-gray-700">登壇応募の締切日です</p>
-                </div>
-              </div>
-            </div>
-            <!-- 3. 参加登録開始 -->
-            <div class="relative flex items-start">
-              <div class="flex flex-col items-center z-10 pr-4" style="width: 3.5rem;">
-                <div class="w-10 h-10 bg-blue-500 border-4 border-white rounded-full flex items-center justify-center shadow-lg mb-2">
-                  <i class="fas fa-user-plus text-white text-xl"></i>
-                </div>
-              </div>
-              <div class="ml-8 flex-1">
-                <div class="bg-white p-6 rounded-xl border border-gray-200 shadow-sm">
-                  <div class="flex items-center mb-2">
-                    <span class="text-lg font-bold text-blue-600 mr-4">2025年6月中旬</span>
-                    <span class="text-gray-900 font-semibold">参加登録開始</span>
-                  </div>
-                  <p class="text-gray-700">イベント参加登録受付を開始</p>
-                </div>
-              </div>
-            </div>
-            <!-- 4. イベント当日 -->
-            <div class="relative flex items-start">
-              <div class="flex flex-col items-center z-10 pr-4" style="width: 3.5rem;">
-                <div class="w-10 h-10 bg-blue-500 border-4 border-white rounded-full flex items-center justify-center shadow-lg mb-2">
-                  <i class="fas fa-calendar-check text-white text-xl"></i>
-                </div>
-              </div>
-              <div class="ml-8 flex-1">
-                <div class="bg-white p-6 rounded-xl border border-gray-200 shadow-sm">
-                  <div class="flex items-center mb-2">
-                    <span class="text-lg font-bold text-blue-600 mr-4">2025年7月26日</span>
-                    <span class="text-gray-900 font-semibold">イベント当日</span>
-                  </div>
-                  <p class="text-gray-700">Devin Meetup Tokyo 開催！</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
 
     <!-- Schedule Section -->
     <section id="schedule" class="py-20 bg-gray-50 scroll-mt-24">
@@ -1417,46 +1330,6 @@
                     Devinの最新技術動向から実践的な活用事例まで、充実したプログラムをご用意しています。
                 </p>
                 
-                <!-- Call for Proposal Banner -->
-                <div class="bg-gradient-to-r from-orange-100 to-red-100 p-6 rounded-xl mb-8 border border-orange-200">
-                    <div class="text-center mb-6">
-                        <h3 class="text-2xl font-bold text-gray-900 mb-4">Call for Proposals 募集中！</h3>
-                        <p class="text-lg text-gray-700 mb-4">
-                            Devinの活用事例、技術解説、実装体験など、あなたの知見をシェアしませんか？
-                        </p>
-                    </div>
-                    
-                    <div class="grid md:grid-cols-2 gap-6 mb-6">
-                        <div class="bg-white p-4 rounded-lg border border-orange-200">
-                            <h4 class="text-lg font-bold text-gray-900 mb-2">募集期間</h4>
-                            <p class="text-gray-700">2025年5月20日 〜 2025年6月13日 24:00ごろ</p>
-                        </div>
-                        <div class="bg-white p-4 rounded-lg border border-orange-200">
-                            <h4 class="text-lg font-bold text-gray-900 mb-2">登壇形式</h4>
-                            <p class="text-gray-700">レギュラートーク（30分）・Short talk（10分）</p>
-                        </div>
-                    </div>
-                    
-                    <div class="bg-white p-6 rounded-xl border border-gray-200 mb-6">
-                        <h4 class="text-xl font-bold text-gray-900 mb-4">こんなトークをお待ちしています</h4>
-                        <p class="text-gray-700 mb-4">
-                            Devinの独創的な活用法や効率的な使い方の体験談・アイデアをご提案ください。
-                        </p>
-                        <ul class="space-y-2 text-gray-700">
-                            <li>• 独自のワークフローや開発プロセスの工夫</li>
-                            <li>• 従来の枠を超えた応用的な使い方</li>
-                            <li>• 生産性向上のためのハックやテクニック</li>
-                            <li>• 他ツールとの創造的な組み合わせ事例</li>
-                        </ul>
-                    </div>
-                    
-                    <div class="text-center">
-                        <a href="https://docs.google.com/forms/d/e/1FAIpQLSdUFdrd5y2m4D0YQ8QgyxfnsNcs9zPdBkgWfeIO_0WWbMfEhQ/viewform?usp=dialog" target="_blank" rel="noopener" class="inline-block bg-gradient-to-r from-orange-500 to-red-500 text-white px-8 py-4 rounded-full font-semibold hover:scale-105 transition-all duration-300 shadow-lg">
-                            <i class="fas fa-microphone mr-2"></i>
-                            CFP応募フォーム
-                        </a>
-                    </div>
-                </div>
             </div>
             
             <div class="max-w-7xl mx-auto">
@@ -2232,4 +2105,4 @@
         });
     </script>
 </body>
-</html>                                                                                                
+</html>                                                                                                                                                                                                


### PR DESCRIPTION
# Remove Timeline and CFP sections completely

## Summary

This PR completely removes the Timeline section and CFP (Call for Proposals) section from the Devin Meetup Tokyo 2025 website as requested. The website now flows directly from the "About Devin" section to the "Event Schedule" section, creating a more streamlined user experience.

**Key Changes:**
- **Timeline Section Removal**: Eliminated the entire timeline section (85+ lines) that displayed event milestones including CFP start date, CFP deadline, registration opening, and event date
- **CFP Section Removal**: Removed the CFP banner and application form from the Schedule section (40+ lines) that provided speaker application details and requirements
- **Layout Simplification**: Website structure now flows: Hero → About → Schedule → Venue → Registration → Footer

**Impact**: 128 lines deleted, significantly reducing page length and complexity while maintaining core event information in the Schedule section.

## Review & Testing Checklist for Human

- [ ] **Business intent verification**: Confirm that completely removing CFP and Timeline sections aligns with current event planning needs (this removes all CFP application functionality)
- [ ] **Navigation integrity**: Test that all navigation links work correctly and don't reference the removed sections
- [ ] **Visual layout verification**: Verify the page flows smoothly from About section directly to Schedule section without awkward spacing or design breaks
- [ ] **Functionality testing**: Check that no JavaScript errors occur and all remaining interactive elements work properly
- [ ] **Content completeness**: Ensure that any essential information from the removed sections that should be preserved is available elsewhere on the site

**Recommended test plan**: Load the site on desktop and mobile, scroll through all sections to verify smooth visual flow, test all navigation links, and confirm no broken functionality or missing critical information.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    index["index.html<br/>(Website main file)"]:::major-edit
    timeline["Timeline Section<br/>(Lines 1321-1407)"]:::major-edit
    cfp["CFP Section<br/>(Lines 1420-1462)"]:::major-edit
    about["About Section<br/>(Preserved)"]:::context
    schedule["Schedule Section<br/>(Preserved)"]:::context
    
    index --> timeline
    index --> cfp
    index --> about
    index --> schedule
    
    timeline -->|"REMOVED"| dates["Event Milestones<br/>(CFP dates, etc.)"]:::major-edit
    cfp -->|"REMOVED"| form["Application Form<br/>(Google Form link)"]:::major-edit
    
    about -->|"Now flows directly to"| schedule
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This is a significant content removal that eliminates all CFP functionality and event timeline information
- The change was tested locally and confirmed to work without layout issues
- No navigation menu updates were needed as the removed sections weren't in the main navigation
- Consider whether any of the removed timeline information should be preserved in the Schedule section if event dates are still relevant

**Link to Devin run:** https://app.devin.ai/sessions/3d3ec53534054c50956f492220561b5f  
**Requested by:** @fumiya-kume

**Before/After Screenshots:**
![Before - With Timeline and CFP sections](file:///home/ubuntu/screenshots/localhost_8000_130944.png)
![After - Sections completely removed](file:///home/ubuntu/screenshots/localhost_8000_132324.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更点**
  * タイムラインセクションをページから削除しました。
  * スケジュールセクション内の「Call for Proposal」バナーを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->